### PR TITLE
Using Microsoft.Build.Locator to locate MSBuild

### DIFF
--- a/src/DotnetThirdPartyNotices/DotnetThirdPartyNotices.csproj
+++ b/src/DotnetThirdPartyNotices/DotnetThirdPartyNotices.csproj
@@ -18,11 +18,10 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
-    <PackageReference Include="Microsoft.Build" Version="15.8.166" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.8.166" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.8.166" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.8.166" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1-beta1" />
+    <PackageReference Include="Microsoft.Build" Version="5.8.166" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.8.166" ExcludeAssets="runtime" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The current approach:
- Uses a Regex which doesn't handle preview versions of the .NET Core correctly
- Has a reference to a specific version of MSBuild, and will fail when another version of MSBuild is resolved.

The Microsoft.Build.Locator package is intended to fix this, so this PR updates the code to use that instead.

https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application?view=vs-2019#use-microsoftbuildlocator has some more details.