### PR TITLE
Don't remove the TargetFramework property, just override it

### DIFF
--- a/src/DotnetThirdPartyNotices/Extensions/ProjectExtensions.cs
+++ b/src/DotnetThirdPartyNotices/Extensions/ProjectExtensions.cs
@@ -19,7 +19,6 @@ namespace DotnetThirdPartyNotices.Extensions
             if (targetFrameworksProperty != null)
             {
                 var targetFrameworks = targetFrameworksProperty.EvaluatedValue.Split(';');
-                project.RemoveProperty(targetFrameworksProperty);
                 project.SetProperty("TargetFramework", targetFrameworks[0]);
             }
 


### PR DESCRIPTION
If the `TargetFramework` is defined in an imported project file, removing that property will fail with this error message:

```
An unhandled exception of type 'System.InvalidOperationException' occurred in System.Private.CoreLib.dll
Cannot modify an evaluated object originating in an imported file "[...]\common.props".
```

Instead, just keep the call to `SetProperty`