### PR TITLE
Search for license in repository url and in local package folder

### DIFF
--- a/src/DotnetThirdPartyNotices/GithubService.cs
+++ b/src/DotnetThirdPartyNotices/GithubService.cs
@@ -32,6 +32,8 @@ internal class GithubService : IDisposable
     public async Task<string> GetLicenseContentFromRepositoryPath(string repositoryPath)
     {
         repositoryPath = repositoryPath.TrimEnd('/');
+        if (repositoryPath.EndsWith(".git"))
+            repositoryPath = repositoryPath[..^4];
         var json = await _httpClient.GetStringAsync($"repos{repositoryPath}/license");
         var jsonDocument = JsonDocument.Parse(json);
 

--- a/src/DotnetThirdPartyNotices/LicenseResolvers/GithubLicenseResolver.cs
+++ b/src/DotnetThirdPartyNotices/LicenseResolvers/GithubLicenseResolver.cs
@@ -5,10 +5,11 @@ using DotnetThirdPartyNotices.LicenseResolvers.Interfaces;
 
 namespace DotnetThirdPartyNotices.LicenseResolvers;
 
-internal class GithubLicenseResolver : ILicenseUriLicenseResolver, IProjectUriLicenseResolver
+internal class GithubLicenseResolver : ILicenseUriLicenseResolver, IProjectUriLicenseResolver, IRepositoryUriLicenseResolver
 {
     bool ILicenseUriLicenseResolver.CanResolve(Uri uri) => uri.IsGithubUri();
     bool IProjectUriLicenseResolver.CanResolve(Uri uri) => uri.IsGithubUri();
+    bool IRepositoryUriLicenseResolver.CanResolve(Uri uri) => uri.IsGithubUri();
 
     Task<string> ILicenseUriLicenseResolver.Resolve(Uri licenseUri)
     {
@@ -18,6 +19,12 @@ internal class GithubLicenseResolver : ILicenseUriLicenseResolver, IProjectUriLi
     }
 
     async Task<string> IProjectUriLicenseResolver.Resolve(Uri projectUri)
+    {
+        using var githubService = new GithubService();
+        return await githubService.GetLicenseContentFromRepositoryPath(projectUri.AbsolutePath);
+    }
+
+    async Task<string> IRepositoryUriLicenseResolver.Resolve(Uri projectUri)
     {
         using var githubService = new GithubService();
         return await githubService.GetLicenseContentFromRepositoryPath(projectUri.AbsolutePath);

--- a/src/DotnetThirdPartyNotices/LicenseResolvers/Interfaces/IRepositoryUriLicenseResolver.cs
+++ b/src/DotnetThirdPartyNotices/LicenseResolvers/Interfaces/IRepositoryUriLicenseResolver.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotnetThirdPartyNotices.LicenseResolvers.Interfaces;
+
+internal interface IRepositoryUriLicenseResolver : ILicenseResolver
+{
+    bool CanResolve(Uri projectUri);
+    Task<string> Resolve(Uri projectUri);
+}

--- a/src/DotnetThirdPartyNotices/LicenseResolvers/LocalPackageLicenseResolver.cs
+++ b/src/DotnetThirdPartyNotices/LicenseResolvers/LocalPackageLicenseResolver.cs
@@ -1,0 +1,32 @@
+﻿using DotnetThirdPartyNotices.LicenseResolvers.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotnetThirdPartyNotices.LicenseResolvers;
+
+internal class LocalPackageLicenseResolver : IFileVersionInfoLicenseResolver
+{
+    public bool CanResolve( FileVersionInfo fileVersionInfo ) => true;
+
+    public async Task<string> Resolve( FileVersionInfo fileVersionInfo )
+    {
+        var packageName = Path.GetFileNameWithoutExtension(fileVersionInfo.FileName);
+        var directoryParts = Path.GetDirectoryName(fileVersionInfo.FileName ).Split('\\', StringSplitOptions.RemoveEmptyEntries);
+        for ( var i = 0; i < directoryParts.Length; i++ )
+        {
+            var directoryPath = string.Join('\\', directoryParts.SkipLast(i));
+            var licensePath = Directory.EnumerateFiles(directoryPath, "license.txt", SearchOption.TopDirectoryOnly)
+                .FirstOrDefault();
+            if (licensePath != null)
+                return await File.ReadAllTextAsync(licensePath);
+            if (directoryPath.EndsWith($"\\{packageName}", StringComparison.OrdinalIgnoreCase))
+                break;
+        }
+        return null;
+    }
+}

--- a/src/DotnetThirdPartyNotices/NuSpec.cs
+++ b/src/DotnetThirdPartyNotices/NuSpec.cs
@@ -13,6 +13,7 @@ public record NuSpec
     public string Version { get; init; }
     public string LicenseUrl { get; init; }
     public string ProjectUrl { get; init; }
+    public string RepositoryUrl { get; init; }
 
     private static NuSpec FromTextReader(TextReader streamReader)
     {
@@ -29,7 +30,8 @@ public record NuSpec
             Id = metadata.Element(ns + "id")?.Value,
             Version = metadata.Element(ns + "version")?.Value,
             LicenseUrl = metadata.Element(ns + "licenseUrl")?.Value,
-            ProjectUrl = metadata.Element(ns + "projectUrl")?.Value
+            ProjectUrl = metadata.Element(ns + "projectUrl")?.Value,
+            RepositoryUrl = metadata.Element(ns + "repository")?.Attribute("url")?.Value
         };
     }
 


### PR DESCRIPTION
Hi,

1. I extended a tool to search for licenses in the repository url stored in Nuget specification.
Sometimes project URL contains custom url but repository URL contains GitHub in most cases.
2. Sometimes repository url ends with ".git". I remove this part because URL with this suffix returns 404.
3. Sometimes package has license.txt file located next to the package files. I added support for this.

I tested the tool with my project and it extracted all licenses.
Great project!
